### PR TITLE
Make .fontra the default when creating a new font

### DIFF
--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -89,8 +89,8 @@ Additionally, it can read (but not write) .ttf, .otf, .woff, .woff2, and .ttx.
 
 fileTypes = [
     # name, extension
-    ("Designspace", "designspace"),
     ("Fontra", "fontra"),
+    ("Designspace", "designspace"),
     ("RoboCJK", "rcjk"),
     ("Unified Font Object", "ufo"),
 ]

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -91,7 +91,6 @@ fileTypes = [
     # name, extension
     ("Fontra", "fontra"),
     ("Designspace", "designspace"),
-    ("RoboCJK", "rcjk"),
     ("Unified Font Object", "ufo"),
 ]
 


### PR DESCRIPTION
Also remove the legacy .rcjk format from the new font format options.