### PR TITLE
feat: add Windows MSI installer via WiX v4 and GitHub Actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -109,13 +109,6 @@ jobs:
 
           xcrun stapler staple "$DMG_PATH"
 
-      - name: Stage Windows exe for MSI installer job
-        if: ${{ matrix.NAME == 'Windows' }}
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force -Path staging
-          Copy-Item "dist\Fontra Pak.exe" "staging\Fontra Pak.exe"
-
       - name: Archive executable with tar
         if: ${{ matrix.NAME != 'MacOS' && matrix.NAME != 'Windows' }}
         run: |
@@ -129,14 +122,8 @@ jobs:
           name: FontraPak-${{ matrix.NAME }}
           path: |
             ./dist/*.dmg
+            ./dist/*.exe
             ./dist/*.tgz
-
-      - name: Storing Windows exe artifact
-        if: ${{ matrix.NAME == 'Windows' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: FontraPak-Windows-exe
-          path: "staging/Fontra Pak.exe"
 
   windows-installer:
     needs: build-application
@@ -159,7 +146,7 @@ jobs:
       - name: Download Windows exe
         uses: actions/download-artifact@v8
         with:
-          name: FontraPak-Windows-exe
+          name: FontraPak-Windows
           path: dist
 
       - name: Install WiX v6
@@ -179,7 +166,7 @@ jobs:
       - name: Storing Windows MSI artifact
         uses: actions/upload-artifact@v7
         with:
-          name: FontraPak-Windows
+          name: FontraPak-Windows-msi
           path: dist/FontraPak-Windows-${{ env.VERSION }}.msi
 
   create-github-release:
@@ -221,7 +208,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             ./downloaded-artifact/FontraPak-MacOS/*.dmg
-            ./downloaded-artifact/FontraPak-Windows/FontraPak-Windows-*.msi
+            ./downloaded-artifact/FontraPak-Windows-msi/FontraPak-Windows-*.msi
             ./downloaded-artifact/FontraPak-Ubuntu/*.tgz
 
       - name: Update website / Repository Dispatch

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -115,15 +115,21 @@ jobs:
           cd ./dist
           tar -czvf FontraPak-${{ matrix.NAME }}.tgz fontrapak
 
-      - name: Storing Artifacts
+      - name: Storing MacOS and Linux Artifacts
         uses: actions/upload-artifact@v7
         if: ${{ matrix.NAME != 'Windows' }}
         with:
           name: FontraPak-${{ matrix.NAME }}
           path: |
             ./dist/*.dmg
-            ./dist/*.exe
             ./dist/*.tgz
+      - name: Storing Windows Artifacts
+        uses: actions/upload-artifact@v7
+        if: ${{ matrix.NAME == 'Windows' }}
+        with:
+          name: FontraPak-${{ matrix.NAME }}-Portable
+          path: |
+            ./dist/*.exe
 
   windows-installer:
     needs: build-application
@@ -146,7 +152,7 @@ jobs:
       - name: Download Windows exe
         uses: actions/download-artifact@v8
         with:
-          name: FontraPak-Windows
+          name: FontraPak-Windows-Portable
           path: dist
 
       - name: Install WiX v6
@@ -166,7 +172,7 @@ jobs:
       - name: Storing Windows MSI artifact
         uses: actions/upload-artifact@v7
         with:
-          name: FontraPak-Windows-msi
+          name: FontraPak-Windows
           path: dist/FontraPak-Windows-${{ env.VERSION }}.msi
 
   create-github-release:
@@ -208,7 +214,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             ./downloaded-artifact/FontraPak-MacOS/*.dmg
-            ./downloaded-artifact/FontraPak-Windows-msi/FontraPak-Windows-*.msi
+            ./downloaded-artifact/FontraPak-Windows/*.msi
             ./downloaded-artifact/FontraPak-Ubuntu/*.tgz
 
       - name: Update website / Repository Dispatch

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -109,11 +109,12 @@ jobs:
 
           xcrun stapler staple "$DMG_PATH"
 
-      - name: Zip Windows exe
+      - name: Stage Windows exe for MSI installer job
         if: ${{ matrix.NAME == 'Windows' }}
+        shell: pwsh
         run: |
-          cd ./dist
-          Compress-Archive -Path "Fontra Pak.exe" -Destination FontraPak-${{ matrix.NAME }}.zip
+          New-Item -ItemType Directory -Force -Path staging
+          Copy-Item "dist\Fontra Pak.exe" "staging\Fontra Pak.exe"
 
       - name: Archive executable with tar
         if: ${{ matrix.NAME != 'MacOS' && matrix.NAME != 'Windows' }}
@@ -123,12 +124,63 @@ jobs:
 
       - name: Storing Artifacts
         uses: actions/upload-artifact@v7
+        if: ${{ matrix.NAME != 'Windows' }}
         with:
           name: FontraPak-${{ matrix.NAME }}
           path: |
             ./dist/*.dmg
-            ./dist/*.zip
             ./dist/*.tgz
+
+      - name: Storing Windows exe artifact
+        if: ${{ matrix.NAME == 'Windows' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: FontraPak-Windows-exe
+          path: "staging/Fontra Pak.exe"
+
+  windows-installer:
+    needs: build-application
+    runs-on: windows-latest
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+
+      - name: Extract version from tag
+        if: github.ref_type == 'tag'
+        shell: pwsh
+        run: echo "VERSION=${{ github.ref_name }}" >> $env:GITHUB_ENV
+
+      - name: Set dev version
+        if: github.ref_type != 'tag'
+        shell: pwsh
+        run: echo "VERSION=0.0.1" >> $env:GITHUB_ENV
+
+      - name: Download Windows exe
+        uses: actions/download-artifact@v8
+        with:
+          name: FontraPak-Windows-exe
+          path: dist
+
+      - name: Install WiX v6
+        shell: pwsh
+        run: dotnet tool install --global wix --version 6.0.2
+
+      - name: Add WiX UI extension
+        shell: pwsh
+        run: wix extension add --global WixToolset.UI.wixext/6.0.2
+
+      - name: Compile MSI
+        shell: pwsh
+        run: |
+          Set-Location windows
+          wix build Product.wxs -arch x64 -d "Version=${{ env.VERSION }}" -ext WixToolset.UI.wixext -o "$env:GITHUB_WORKSPACE\dist\FontraPak-Windows-${{ env.VERSION }}.msi"
+
+      - name: Storing Windows MSI artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: FontraPak-Windows
+          path: dist/FontraPak-Windows-${{ env.VERSION }}.msi
 
   create-github-release:
     runs-on: ubuntu-latest
@@ -136,7 +188,7 @@ jobs:
     permissions:
       contents: write
 
-    needs: [build-application]
+    needs: [build-application, windows-installer]
     if: github.ref_type == 'tag'
 
     steps:
@@ -169,7 +221,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             ./downloaded-artifact/FontraPak-MacOS/*.dmg
-            ./downloaded-artifact/FontraPak-Windows/*.zip
+            ./downloaded-artifact/FontraPak-Windows/FontraPak-Windows-*.msi
             ./downloaded-artifact/FontraPak-Ubuntu/*.tgz
 
       - name: Update website / Repository Dispatch

--- a/windows/Product.wxs
+++ b/windows/Product.wxs
@@ -14,7 +14,7 @@
     <Icon Id="AppIcon" SourceFile="..\icon\FontraIcon.ico" />
     <Property Id="ARPPRODUCTICON" Value="AppIcon" />
     <Property Id="ARPHELPLINK" Value="https://fontra.xyz" />
-    <Property Id="CREATEDESKTOPSHORTCUT" Value="1" />
+
     <StandardDirectory Id="ProgramFiles64Folder">
       <Directory Id="INSTALLFOLDER" Name="Fontra Pak">
         <Component Id="MainExecutable" Guid="B89F59EB-427A-4D98-B5E9-0E4415334903">
@@ -46,7 +46,6 @@
 
     <StandardDirectory Id="DesktopFolder">
       <Component Id="DesktopShortcut" Guid="F61FDE49-7169-40DA-98B6-B3B3436FB807">
-        <Condition>CREATEDESKTOPSHORTCUT="1"</Condition>
         <Shortcut Id="DesktopShortcut"
                   Name="Fontra Pak"
                   Description="Fontra Pak font editor"

--- a/windows/Product.wxs
+++ b/windows/Product.wxs
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- windows/Product.wxs -->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package
+      Name="Fontra Pak"
+      Language="1033"
+      Version="$(var.Version)"
+      Manufacturer="Fontra Contributors"
+      UpgradeCode="7D55E932-DDE6-4AEC-BF13-74A2855617E9">
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of Fontra Pak is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <Icon Id="AppIcon" SourceFile="..\icon\FontraIcon.ico" />
+    <Property Id="ARPPRODUCTICON" Value="AppIcon" />
+    <Property Id="ARPHELPLINK" Value="https://fontra.xyz" />
+
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="Fontra Pak">
+        <Component Id="MainExecutable" Guid="B89F59EB-427A-4D98-B5E9-0E4415334903">
+          <File Id="FontraPakExe"
+                Source="..\dist\Fontra Pak.exe"
+                KeyPath="yes" />
+        </Component>
+      </Directory>
+    </StandardDirectory>
+
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="AppMenuFolder" Name="Fontra Pak">
+        <Component Id="StartMenuShortcut" Guid="53433077-6B28-435E-AB3A-180CC64A9B4D">
+          <Shortcut Id="StartMenuShortcut"
+                    Name="Fontra Pak"
+                    Description="Fontra Pak font editor"
+                    Target="[INSTALLFOLDER]Fontra Pak.exe"
+                    WorkingDirectory="INSTALLFOLDER" />
+          <RemoveFolder Id="AppMenuFolderRemove" On="uninstall" />
+          <RegistryValue Root="HKLM"
+                         Key="Software\Fontra Pak"
+                         Name="StartMenuShortcut"
+                         Type="integer"
+                         Value="1"
+                         KeyPath="yes" />
+        </Component>
+      </Directory>
+    </StandardDirectory>
+
+    <StandardDirectory Id="DesktopFolder">
+      <Component Id="DesktopShortcut" Guid="F61FDE49-7169-40DA-98B6-B3B3436FB807">
+        <Shortcut Id="DesktopShortcut"
+                  Name="Fontra Pak"
+                  Description="Fontra Pak font editor"
+                  Target="[INSTALLFOLDER]Fontra Pak.exe"
+                  WorkingDirectory="INSTALLFOLDER" />
+        <RegistryValue Root="HKLM"
+                       Key="Software\Fontra Pak"
+                       Name="DesktopShortcut"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes" />
+      </Component>
+    </StandardDirectory>
+
+    <Feature Id="MainFeature" Title="Fontra Pak" Level="1">
+      <ComponentRef Id="MainExecutable" />
+      <ComponentRef Id="StartMenuShortcut" />
+      <ComponentRef Id="DesktopShortcut" />
+    </Feature>
+  </Package>
+</Wix>

--- a/windows/Product.wxs
+++ b/windows/Product.wxs
@@ -14,7 +14,7 @@
     <Icon Id="AppIcon" SourceFile="..\icon\FontraIcon.ico" />
     <Property Id="ARPPRODUCTICON" Value="AppIcon" />
     <Property Id="ARPHELPLINK" Value="https://fontra.xyz" />
-
+    <Property Id="CREATEDESKTOPSHORTCUT" Value="1" />
     <StandardDirectory Id="ProgramFiles64Folder">
       <Directory Id="INSTALLFOLDER" Name="Fontra Pak">
         <Component Id="MainExecutable" Guid="B89F59EB-427A-4D98-B5E9-0E4415334903">
@@ -46,6 +46,7 @@
 
     <StandardDirectory Id="DesktopFolder">
       <Component Id="DesktopShortcut" Guid="F61FDE49-7169-40DA-98B6-B3B3436FB807">
+        <Condition>CREATEDESKTOPSHORTCUT="1"</Condition>
         <Shortcut Id="DesktopShortcut"
                   Name="Fontra Pak"
                   Description="Fontra Pak font editor"


### PR DESCRIPTION
This fixes #209, supersedes #235.

- Add packaging/windows/Product.wxs: WiX v4/v6 compatible MSI that installs Fontra Pak to Program Files (x64), creates Start Menu and Desktop shortcuts, registers with Windows Apps & Features, and supports major upgrades and silent uninstall.

- Update .github/workflows/python-app.yml: replace Windows zip step with a separate windows-installer job that builds the MSI using wix CLI 6.0.2 with pinned WixToolset.UI.wixext/6.0.2 and attaches FontraPak-Windows-x.y.z.msi to the GitHub Release.

- All GUIDs are unique to Fontra Pak and will not conflict with any other WiX-based installer on the same machine.

- Version is injected automatically from the Git tag.