### PR TITLE
Fix "Open fonts in read-only mode" on Windows

### DIFF
--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -189,7 +189,7 @@ class FontraMainWidget(QMainWindow):
         readOnlyCheckBox = QCheckBox("Open fonts in read-only mode")
         readOnlyCheckBox.setCheckState(
             Qt.CheckState.Checked
-            if applicationSettings.value("openFontsInReadOnlyMode", False)
+            if applicationSettings.value("openFontsInReadOnlyMode", False, type=bool)
             else Qt.CheckState.Unchecked
         )
         readOnlyCheckBox.stateChanged.connect(
@@ -557,7 +557,7 @@ def openFile(path, port):
         del parts[0]
     path = "/".join(quote(part, safe="") for part in parts)
 
-    readOnly = applicationSettings.value("openFontsInReadOnlyMode", False)
+    readOnly = applicationSettings.value("openFontsInReadOnlyMode", False, type=bool)
     sampleText = applicationSettings.value("editorSampleText", "")
     urlFragment = dumpURLFragment({"text": sampleText}) if sampleText else ""
     view = "editor" if sampleText else "fontoverview"


### PR DESCRIPTION
- Pass explicit type to settings.value() to ensure we receive a boolean

It turns out QSettings serialization on Windows works a little different than on macOS: a stored boolean may later be retrieved as a string "false" or "true". By asking for the reight type explicitly, we should get the correct answer.

This fixes an issue when the "Open fonts in read-only mode" checkbox sometimes had no effect or the opposite effect.