### PR TITLE
Explicitly set SSL_CERT_FILE so we can reliably do https requests with urllib

### DIFF
--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -18,6 +18,7 @@ from random import random
 from urllib.parse import quote
 from urllib.request import urlopen
 
+import certifi
 import psutil
 from fontra import __version__ as fontraVersion
 from fontra.backends import getFileSystemBackend, newFileSystemBackend
@@ -681,6 +682,8 @@ def queueGetter(queue, callback):
 
 
 def main():
+    os.environ["SSL_CERT_FILE"] = certifi.where()
+
     queue = multiprocessing.Queue()
     host = "localhost"
     port = findFreeTCPPort(host=host)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ PyQt6==6.7.1
 PyQt6-Qt6==6.7.3
 PyQt6-sip==13.10.3
 psutil==7.2.2
+certifi==2026.5.20


### PR DESCRIPTION
This is only for the "check for updates" functionality, which apparently never properly worked in a reliable way.