### PR TITLE
fix(linux): force XCB on GNOME Wayland to restore titlebar buttons

### DIFF
--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -1,12 +1,18 @@
+import os
+import sys
+
+if sys.platform == "linux" and "QT_QPA_PLATFORM" not in os.environ:
+    desktop = os.environ.get("XDG_CURRENT_DESKTOP", "").lower()
+    if "gnome" in desktop or "mutter" in desktop:
+        os.environ["QT_QPA_PLATFORM"] = "xcb"
+
 import asyncio
 import json
 import logging
 import multiprocessing
-import os
 import pathlib
 import secrets
 import signal
-import sys
 import tempfile
 import threading
 import traceback

--- a/FontraPakMain.py
+++ b/FontraPakMain.py
@@ -2,6 +2,9 @@ import os
 import sys
 
 if sys.platform == "linux" and "QT_QPA_PLATFORM" not in os.environ:
+    # GNOME/Mutter does not support Wayland server-side decorations (SSD),
+    # rendering Qt windows without titlebar buttons. Force XCB on GNOME to
+    # restore window controls via Xwayland.
     desktop = os.environ.get("XDG_CURRENT_DESKTOP", "").lower()
     if "gnome" in desktop or "mutter" in desktop:
         os.environ["QT_QPA_PLATFORM"] = "xcb"


### PR DESCRIPTION
### Summary
Fixes missing/unresponsive window titlebar control buttons (close, minimize, maximize) on Linux GNOME Wayland sessions by falling back to XCB (`QT_QPA_PLATFORM=xcb`).

### Problem
GNOME/Mutter strictly enforces Client-Side Decorations (CSD) and does not support Server-Side Decoration (SSD) protocols over Wayland for standard Qt windows. As a result, Qt applications running natively on GNOME Wayland can render without functioning window controls.
<img width="1920" height="1080" alt="Screenshot From 2026-09-06 20-06-37" src="https://github.com/user-attachments/assets/6c7dad07-024f-49d1-8396-07da0a3b2f30" />

### Solution
- Check if `sys.platform == "linux"` and `XDG_CURRENT_DESKTOP` contains `gnome` or `mutter`.
- Set `os.environ["QT_QPA_PLATFORM"] = "xcb"` prior to initializing Qt if no explicit `QT_QPA_PLATFORM` override exists in the environment.
- Non-GNOME compositors (KDE Plasma, Hyprland, Sway) continue to run natively on Wayland without interference.
<img width="1920" height="1080" alt="Screenshot From 2026-09-06 20-33-59" src="https://github.com/user-attachments/assets/0181492f-91fb-40f2-835f-f03e45bcd105" />

### Testing
Verified standalone binaries on:
- **Ubuntu 22.04** (GNOME 42 / Wayland)
- **Debian 13** (GNOME 47 / Wayland)
- **Fedora 44** (GNOME 50 / Wayland)